### PR TITLE
Enable auto-merge for Dependabot Pull Requests

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,6 @@
+- match:
+    dependency_type: devDependencies
+    update_type: "semver:minor"
+- match:
+    dependency_type: dependencies
+    update_type: "semver:patch"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,15 @@
+name: auto-merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: ${{ secrets.QUIPPERTECH_GITHUB_API_TOKEN_FOR_PUBLIC_REPO }}


### PR DESCRIPTION
This is to auto-merge some Pull Requests by dependabot.

## Auto-merge criteria

### dependencies

* patch-level upgrades only

### devDependencies

* patch-level and minor-level upgrades

---

It works like this one:
https://github.com/yuya-takeyama/auto-cancel-redundant-workflow-runs-action/pull/10

This approval is sent automatically from GitHub Actions:
![image](https://user-images.githubusercontent.com/241542/110601956-d6ac7200-81c8-11eb-9649-8436ef133ff3.png)

And if all of the CI statuses are green, dependable will automatically merge the Pull Request:
![image](https://user-images.githubusercontent.com/241542/110602118-fe9bd580-81c8-11eb-88dc-0f96ca1468d7.png)
