### PR TITLE
Run comment-failure even if preceding workflow succeeds

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   comment-failure:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - uses: quipper/comment-failure-action@v0.1.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ on:
 
 jobs:
   comment-failure:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - uses: quipper/comment-failure-action@v0.1.0
@@ -36,7 +35,6 @@ on:
 
 jobs:
   comment-failure:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - uses: quipper/comment-failure-action@v0.1.0


### PR DESCRIPTION
We need this change to update the comment when re-run clears job failures.
After merging this commit, comment-failure will create a comment if no jobs failed, too.