### PR TITLE
Run auto-merge on pull_request_target only from dependabot

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,13 +1,12 @@
 name: auto-merge
 
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request_target:
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2


### PR DESCRIPTION
As https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/ describes, dependabot creates pull requests from a forked repository. So we need run auto-merge on `pull_request_target`.

We need to verify whether the creator of the pull request is dependabot or not to keep secure.

https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60#issuecomment-806027389 and  https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60#issuecomment-806170152 helped me, thanks!